### PR TITLE
Align operation values to 4 bits

### DIFF
--- a/src/dut/sv/shape_processor.sv
+++ b/src/dut/sv/shape_processor.sv
@@ -28,7 +28,7 @@ module shape_processor(
 
   struct {
     bit [1:0] shape;
-    bit [4:0] operation;
+    bit [5:0] operation;
   } ctrl_sfr;
 
 
@@ -41,19 +41,19 @@ module shape_processor(
       new_shape = write_data[17:16];
 
 
-  bit [4:0] new_operation;
+  bit [5:0] new_operation;
 
   always_comb
-    if (write_data[4:0] == '1)
+    if (write_data[5:0] == '1)
       new_operation = ctrl_sfr.operation;
     else
-      new_operation = write_data[4:0];
+      new_operation = write_data[5:0];
 
 
   always_ff @(posedge clk or negedge rst_n)
     if (!rst_n) begin
       ctrl_sfr.shape <= 'b01;
-      ctrl_sfr.operation <= 'b00_000;
+      ctrl_sfr.operation <= 'b00_0000;
     end
     else begin
       if (write) begin
@@ -72,23 +72,23 @@ module shape_processor(
   endfunction
 
 
-  function bit is_legal_operation(bit [4:0] val);
-    case (val[4:3])
+  function bit is_legal_operation(bit [5:0] val);
+    case (val[5:4])
       'b00:
-        return val[2:0] inside { 0, 1 };
+        return val[3:0] inside { 0, 1 };
       'b01:
-        return val[2:0] == 0;
+        return val[3:0] == 0;
       'b10:
-        return val[2:0] inside { 0, 1 };
+        return val[3:0] inside { 0, 1 };
     endcase
     return 0;
   endfunction
 
 
-  function bit is_legal_combination(bit [1:0] shape, bit [4:0] operation);
-    if (operation[4:3] == 0)
+  function bit is_legal_combination(bit [1:0] shape, bit [5:0] operation);
+    if (operation[5:4] == 0)
       return 1;
-    return operation[4:3] == shape;
+    return operation[5:4] == shape;
   endfunction
 
 endmodule

--- a/src/formal/sv/shape_processor_modeling.sv
+++ b/src/formal/sv/shape_processor_modeling.sv
@@ -18,8 +18,8 @@ package shape_processor_modeling;
   typedef struct packed {
     bit [13:0] reserved1;
     bit [1:0] SHAPE;
-    bit [10:0] reserved0;
-    bit [4:0] OPERATION;
+    bit [9:0] reserved0;
+    bit [5:0] OPERATION;
   } ctrl_sfr_reg;
 
 
@@ -29,12 +29,12 @@ package shape_processor_modeling;
     KEEP_SHAPE = '1
   } shape_e;
 
-  typedef enum bit [4:0] {
-    PERIMETER = 'b00_000,
-    AREA = 'b00_001,
-    IS_SQUARE = 'b01_000,
-    IS_EQUILATERAL = 'b10_000,
-    IS_ISOSCELES = 'b10_001,
+  typedef enum bit [5:0] {
+    PERIMETER = 'b00_0000,
+    AREA = 'b00_0001,
+    IS_SQUARE = 'b01_0000,
+    IS_EQUILATERAL = 'b10_0000,
+    IS_ISOSCELES = 'b10_0001,
     KEEP_OPERATION = '1
   } operation_e;
 
@@ -44,7 +44,7 @@ package shape_processor_modeling;
   endfunction
 
 
-  function bit is_legal_operation(bit [4:0] val);
+  function bit is_legal_operation(bit [5:0] val);
     return val inside { KEEP_OPERATION, PERIMETER, AREA, IS_SQUARE, IS_EQUILATERAL, IS_ISOSCELES };
   endfunction
 


### PR DESCRIPTION
This makes it much easier to debug the waves, as the hex values of the
shape field and the upper part of the operation field match.